### PR TITLE
Don't use C-x SPC since newer Emacs use that for rectangular selection

### DIFF
--- a/edebug-x.el
+++ b/edebug-x.el
@@ -378,7 +378,7 @@ for each."
 (define-minor-mode edebug-x-mode
   "A minor mode that makes it easier to use Edebug"
   :keymap (let ((map (make-sparse-keymap)))
-            (define-key map (kbd "C-x SPC") 'edebug-x-modify-breakpoint-wrapper)
+            (define-key map (kbd "C-c C-x m") 'edebug-x-modify-breakpoint-wrapper)
             (define-key map (kbd "C-c C-x s") 'edebug-x-show-data)
             (define-key map (kbd "C-c C-x b") 'edebug-x-show-breakpoints)
             (define-key map (kbd "C-c C-x i") 'edebug-x-show-instrumented)


### PR DESCRIPTION
Hey Scott!

I like edebug and am looking forward to using it with emacs lisp. But newer versions of emacs use C-x SPC to select rectangularly.  `edebug` overrides that behaviour.

With this change `'edebug-x-modify-breakpoint-wrapper` will be mapped to `C-c C-x m` in line with the rest of the keys mapped in the package.

Cheers,

Andreas.